### PR TITLE
Fixed dependency name for loading it as expected

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2,7 +2,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use WPcomSpecialProjects\Scaffold\Plugin;
+use WPCOMSpecialProjects\Scaffold\Plugin;
 
 // region
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Wit this fix, we'll avoid avoid these errors after enabling the plugin with a default installation (with vendors installed):

![image](https://github.com/a8cteam51/team51-plugin-scaffold/assets/1044309/5a7a6a3b-e60c-46be-812f-eb937c4455d9)

Caused by:

<img width="1179" alt="image" src="https://github.com/a8cteam51/team51-plugin-scaffold/assets/1044309/e18238d7-aae6-43c9-9437-7e92fbe7d66f">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build this plugin with `composer install` or download it from `Upload the artifact` step [on our template repository](https://github.com/Automattic/githubdeployments-plugin-template4/actions/runs/7800813722/job/21274521905)
* Upload it to a site and ensure it doesn't break the site

